### PR TITLE
add logic if resident or non resident for blotter

### DIFF
--- a/src/app/Admin/Official/[...page]/page.js
+++ b/src/app/Admin/Official/[...page]/page.js
@@ -208,8 +208,11 @@ export default function Official({ params }) {
     status_resolved: '',
     complaint_remarks: '',
     is_resident: null,
+    is_resident_complainant: null,
     complainee_id: '',
+    complainant_id:'',
     search: '',
+    searchFirst: '',
     officer_on_duty: ''
   })
 
@@ -3549,7 +3552,47 @@ export default function Official({ params }) {
                 </div>
                 <div class="d-flex align-items-center flex-column justify-content-center w-100 p-5" >
 
-                  <div class="mb-3 w-100">
+
+                {
+                        !isViewing && 
+
+                        <div className="d-flex align-items-center w-100 mb-3">
+                        <div class="form-check">
+                          <input 
+                            
+                            onChange={() => {
+    
+                              setBlotter({
+                                ...blotter, ...{
+                                  is_resident_complainant: true
+                                }
+                              })
+                            }}   
+                            class="form-check-input" type="radio" name="flexRadioDefault2" id="flexRadioDefault3" />
+                          <label class="form-check-label" for="flexRadioDefault3">
+                            Resident
+                          </label>
+                        </div>
+                        <div class="form-check ms-3">
+                          <input 
+                             onChange={() => {
+    
+                              setBlotter({
+                                ...blotter, ...{
+                                  is_resident_complainant: false
+                                }
+                              })
+                            }}
+                          class="form-check-input" type="radio" name="flexRadioDefaul2" id="flexRadioDefault4" />
+                          <label class="form-check-label" for="flexRadioDefault4">
+                            Non-resident
+                          </label>
+                        </div>
+                      </div>
+                      }
+
+
+                  <div class="mb-3 w-100" style={{position:"relative"}}>
                     <label class="form-label">Complainant</label>
                     <input
                       disabled={isViewing ? true : false}
@@ -3560,12 +3603,45 @@ export default function Official({ params }) {
 
                         setBlotter({
                           ...blotter, ...{
-                            complainant_name: val.target.value
+                            complainant_name: val.target.value,
+                            complainee_id: '',
+                            searchFirst: val.target.value
                           }
                         })
 
+                        searchUser(val.target.value)
+
                       }}
                       class="form-control" />
+
+            {
+                        blotter.searchFirst != "" && blotter.is_resident_complainant &&
+                      <div className="box position-absolute w-100" style={{ maxHeight: "300px", overflow: "scroll", width: "500px", zIndex: 999999 }}>
+                        {
+                          searchUserList.map((i, k) => {
+                            return (
+                              <div
+                                onClick={() => {
+                                  
+                                  setBlotter({
+                                    ...blotter, ...{
+                                      complainant_id: i.id,
+                                      complainant_name: i.full_name,
+                                      searchFirst: ''
+                                    }
+                                  })
+                                  console.log(i)
+                                }}
+                                className="search-item pointer">
+                                <span>
+                                  {i.first_name + " " + i.middle_name + " " + i.last_name}
+                                </span>
+                              </div>
+                            )
+                          })
+                        }
+                      </div>
+                    }
 
                   </div>
 
@@ -3735,7 +3811,7 @@ export default function Official({ params }) {
 
                           result = !isViewing ? await dispatch(fileBlotterReportApi(merge)).unwrap() : await dispatch(editBlotterReportApi(merge)).unwrap();
 
-
+                          setIsViewing(false)
                           setShowBlotter(false)
                           setSuccess(true)
                           setShowSuccess(true)
@@ -3750,7 +3826,7 @@ export default function Official({ params }) {
                             complainee_id: '',
                             search: ''
                           })
-                          setIsViewing(false)
+                         
                           setLoading(false)
                           // Handle success, e.g., navigate to another page
                         } catch (error) {

--- a/src/redux/reducer/resident.js
+++ b/src/redux/reducer/resident.js
@@ -35,7 +35,7 @@ apiClient.interceptors.response.use(
 // Define async thunks
 export const applyNewResidentApi = createAsyncThunk('user/applyNewResident', async (data) => {
   let params = data
-  
+
   const res = await apiClient.post('/applyNewResident', {
     ...params.resident, ...{
       birthday: moment(params.birthday).format("YYYY-MM-DD"),
@@ -239,10 +239,11 @@ export const fileBlotterReportApi = createAsyncThunk('user/fileBlotterReport', a
 
   const res = await apiClient.post('/fileBlotterReport', {
     complainee_name: data.complainee_id == "" ? data.complainee_name : '',
-      complainant_name: data.complainant_name,
+    complainant_name: data.complainant_id == "" ? data.complainant_name : '',
     status_resolved: data.status_resolved,
-     complaint_remarks: data.complaint_remarks,
+    complaint_remarks: data.complaint_remarks,
     complainee_id: data.complainee_id,
+    complainant_id: data.complainant_id,
     officer_on_duty: data.officer_on_duty
 
   }, {
@@ -282,10 +283,10 @@ export const importExcelResidentsApi = createAsyncThunk('user/importExcelResiden
 
 
   const formData = new FormData();
- 
-  
+
+
   data.files.map((i, k) => {
-    
+
     formData.append('file_upload', i);
   })
 
@@ -293,8 +294,8 @@ export const importExcelResidentsApi = createAsyncThunk('user/importExcelResiden
   formData.forEach((value, key) => {
     formDataObj[key] = value;
   });
-  
-  
+
+
   const res = await apiClient.post('/importExcelResidents', formData, {
     headers: {
       'Authorization': `Bearer ${data.token}`, // Replace with your actual token
@@ -388,7 +389,7 @@ const usersSlice = createSlice({
         state.status = 'failed';
       });
 
-      builder
+    builder
       .addCase(viewAllBlottersApi.pending, (state) => {
         state.status = 'loading';
         state.list.data = []


### PR DESCRIPTION
Good day, This commit includes the following changes:
-Implemented logic to differentiate between residents and non-residents when filing a blotter report.
-Added input handling for identifying if the complainant is a resident or non-resident.
-Updated UI components to reflect the additional checkbox for selecting resident or non-resident status.
Kindly review. Thank you!